### PR TITLE
Don't install PyStokes from the example notebooks

### DIFF
--- a/examples/ex1-unboundedFlow.ipynb
+++ b/examples/ex1-unboundedFlow.ipynb
@@ -23,21 +23,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
-    "## compile PyStokes for this notebook\n",
-    "import os\n",
-    "owd = os.getcwd()\n",
-    "os.chdir('../')\n",
-    "%run setup.py install\n",
-    "os.chdir(owd)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "%matplotlib inline\n",
     "import pystokes\n",
     "import numpy as np, matplotlib.pyplot as plt"

--- a/examples/ex2-flowPlaneSurface.ipynb
+++ b/examples/ex2-flowPlaneSurface.ipynb
@@ -34,21 +34,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
-    "## compile PyStokes for this notebook\n",
-    "import os\n",
-    "owd = os.getcwd()\n",
-    "os.chdir('../')\n",
-    "%run setup.py install\n",
-    "os.chdir(owd)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "%matplotlib inline\n",
     "import pystokes\n",
     "import numpy as np, matplotlib.pyplot as plt"

--- a/examples/ex3-crystalNucleation.ipynb
+++ b/examples/ex3-crystalNucleation.ipynb
@@ -6,21 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
-    "## compile PyStokes for this notebook\n",
-    "import os\n",
-    "owd = os.getcwd()\n",
-    "os.chdir('../')\n",
-    "%run setup.py install\n",
-    "os.chdir(owd)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "%matplotlib inline\n",
     "import pystokes, numpy as np, matplotlib.pyplot as plt"
    ]

--- a/examples/ex4-crystallization.ipynb
+++ b/examples/ex4-crystallization.ipynb
@@ -6,21 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
-    "## compile PyStokes for this notebook\n",
-    "import os\n",
-    "owd = os.getcwd()\n",
-    "os.chdir('../')\n",
-    "%run setup.py install\n",
-    "os.chdir(owd)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "%matplotlib inline\n",
     "import pystokes \n",
     "import numpy as np, matplotlib.pyplot as plt"

--- a/examples/ex5-phoreticField.ipynb
+++ b/examples/ex5-phoreticField.ipynb
@@ -4,21 +4,6 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%capture\n",
-    "## compile PyStokes for this notebook\n",
-    "import os\n",
-    "owd = os.getcwd()\n",
-    "os.chdir('../')\n",
-    "%run setup.py install\n",
-    "os.chdir(owd)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
    "outputs": [
     {
      "data": {

--- a/examples/ex6-arrestedCluster.ipynb
+++ b/examples/ex6-arrestedCluster.ipynb
@@ -6,21 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
-    "## compile PyStokes for this notebook\n",
-    "import os\n",
-    "owd = os.getcwd()\n",
-    "os.chdir('../')\n",
-    "%run setup.py install\n",
-    "os.chdir(owd)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "%matplotlib inline\n",
     "import pystokes \n",
     "import numpy as np, matplotlib.pyplot as plt"

--- a/examples/ex7-benchmark.ipynb
+++ b/examples/ex7-benchmark.ipynb
@@ -6,21 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
-    "## compile PyStokes for this notebook\n",
-    "import os\n",
-    "owd = os.getcwd()\n",
-    "os.chdir('../')\n",
-    "%run setup.py install\n",
-    "os.chdir(owd)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "%matplotlib inline\n",
     "import numpy as np, matplotlib.pyplot as plt, pystokes, time, matplotlib as mpl\n",
     "\n",


### PR DESCRIPTION
1) Depending on how users have installed Python, this can fail.
2) It's not good practice.
If you think it's necessary, add a comment remining users that they
need to install PyStokes first.