### PR TITLE
Fix references in paper.bib

### DIFF
--- a/docs/paper/paper.bib
+++ b/docs/paper/paper.bib
@@ -13,7 +13,7 @@
     volume={19},
     number={9},
     pages={735--748},
-    doi={10.1137/1.9781611973242},
+    url={http://faculty.washington.edu/finlayso/MWR-AReview.pdf},
     year={1966}
 }
 
@@ -151,6 +151,7 @@
 }
 
 @article{bolitho2020,
+    title = {Periodic Orbits of Active Particles Induced by Hydrodynamic Monopoles},
     author = {Bolitho, A. and Singh, R. and Adhikari, R.},
     journal = {Phys. Rev. Lett.},
     doi={10.1103/PhysRevLett.124.088003},


### PR DESCRIPTION
I've made a couple of changes to paper.bib to fix the references:

Added a title to bolitho2020.

Removed the incorrect DOI for finlayson1966method and instead provided a url (I was unable to find a correct DOI)